### PR TITLE
PostgreSQL 11 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#
+db_settings.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ jobs:
     before_script:
      - echo "\set ON_ERROR_STOP on" > ~/.psqlrc
     script:
-     - cd sql; POSTGRES_USER=postgres ./create-db.sh
+     - cd sql; sed -e 's/@DB_USER@/postgres/' db_settings.sh.template > db_settings.sh; POSTGRES_USER=postgres ./create-db.sh
      - psql -U postgres loss < common.sql
      - psql -U postgres loss < loss-schema.sql

--- a/python/export_loss_model.py
+++ b/python/export_loss_model.py
@@ -110,7 +110,7 @@ def _load_contribution(cursor, model_id):
 
 
 _LOSS_MAP_QUERY = """
-SELECT * FROM loss.loss_map WHERE loss_model_id=%s
+SELECT * FROM loss.loss_map WHERE loss_model_id=%s ORDER BY id
 """
 
 
@@ -130,8 +130,9 @@ def _load_loss_maps(cursor, loss_model_id):
 
 
 _LOSS_MAP_VALUES_QUERY = """
-SELECT loss, asset_ref, ST_AsText(the_geom) AS geometry
-FROM loss.loss_map_values WHERE loss_map_id=%s
+SELECT loss, asset_ref, ST_AsText(ST_Normalize(the_geom)) AS geometry
+FROM loss.loss_map_values WHERE loss_map_id=%s 
+ORDER BY id
 """
 
 
@@ -147,7 +148,7 @@ def _load_loss_map_values(cursor, loss_map_id, lm):
 
 
 _LOSS_CURVE_MAP_QUERY = """
-SELECT * FROM loss.loss_curve_map WHERE loss_model_id=%s
+SELECT * FROM loss.loss_curve_map WHERE loss_model_id=%s ORDER BY id
 """
 
 
@@ -169,6 +170,7 @@ def _load_loss_curve_maps(cursor, loss_model_id):
 _LOSS_CURVE_MAP_VALUES_QUERY = """
 SELECT losses, rates, asset_ref, ST_AsText(the_geom) AS geometry
 FROM loss.loss_curve_map_values WHERE loss_curve_map_id=%s
+ORDER BY id
 """
 
 

--- a/python/export_loss_model.py
+++ b/python/export_loss_model.py
@@ -218,7 +218,8 @@ def _export_loss_model(model_id):
 def dumper(obj):
     try:
         if isinstance(obj, datetime.date):
-            return dict(year=obj.year, month=obj.month, day=obj.day)
+            # Ensure that dates are returned as strings, not dictionaries
+            return str(obj)
         return obj.as_dict()
     except AttributeError:
         return obj.__dict__

--- a/python/export_loss_model.py
+++ b/python/export_loss_model.py
@@ -131,7 +131,7 @@ def _load_loss_maps(cursor, loss_model_id):
 
 _LOSS_MAP_VALUES_QUERY = """
 SELECT loss, asset_ref, ST_AsText(ST_Normalize(the_geom)) AS geometry
-FROM loss.loss_map_values WHERE loss_map_id=%s 
+FROM loss.loss_map_values WHERE loss_map_id=%s
 ORDER BY id
 """
 
@@ -217,6 +217,11 @@ def _export_loss_model(model_id):
 
 def dumper(obj):
     try:
+        if isinstance(obj, LossMap) or isinstance(obj, LossCurveMap):
+            # Remove directives before exporting
+            d = obj.__dict__
+            del d['directives']
+            return d
         if isinstance(obj, datetime.date):
             # Ensure that dates are returned as strings, not dictionaries
             return str(obj)

--- a/python/import_loss_model.py
+++ b/python/import_loss_model.py
@@ -124,17 +124,19 @@ _LOSS_MAP_VALUES_QUERY = """
 INSERT INTO loss.loss_map_values (
     loss_map_id, asset_ref, the_geom, loss)
 VALUES (
-    %s, %s, %s, %s
+    %s, %s, ST_GeomFromText(%s,4326), %s
 )
 """
 
 
 def _import_loss_map_values(cursor, loss_map_id, lm_values):
+    verbose_message("Importing {0} lm values for {1}\n".format(len(lm_values),loss_map_id))
     for lmv in lm_values:
+        verbose_message("Importing lm value {0} {1}\n".format(lmv.asset_ref,lmv.loss))
         cursor.execute(_LOSS_MAP_VALUES_QUERY, [
             loss_map_id,
             lmv.asset_ref,
-            lmv.the_geom,
+            lmv.geometry,
             lmv.loss
         ])
 
@@ -159,6 +161,7 @@ def _import_loss_maps(cursor, loss_model_id, loss_maps):
         if d is not None:
             q = d.get('_cf_loss_map_value_data_query')
             if q is not None:
+                verbose_message("Import LM found query {0}".format(q))
                 _import_loss_map_values_via_query(cursor, lmid, q)
                 return
         _import_loss_map_values(cursor, lmid, lm.values)
@@ -204,10 +207,10 @@ def _import_loss_curve_map_values_via_query(cursor, lmcmid, query):
 
 
 _LOSS_CURVE_MAP_VALUES_QUERY = """
-INSERT INTO loss.loss_map_values (
-    loss_map_id, asset_ref, the_geom, losses, rates)
+INSERT INTO loss.loss_curve_map_values (
+    loss_curve_map_id, asset_ref, the_geom, losses, rates)
 VALUES (
-    %s, %s, %s, %s, %s
+    %s, %s, ST_GeomFromText(%s,4326), %s, %s
 )
 """
 
@@ -217,7 +220,7 @@ def _import_loss_curve_map_values(cursor, loss_map_id, lcm_values):
         cursor.execute(_LOSS_CURVE_MAP_VALUES_QUERY, [
             loss_map_id,
             lcmv.asset_ref,
-            lcmv.the_geom,
+            lcmv.geometry,
             lcmv.losses,
             lcmv.rates
         ])

--- a/python/import_loss_model.py
+++ b/python/import_loss_model.py
@@ -130,9 +130,9 @@ VALUES (
 
 
 def _import_loss_map_values(cursor, loss_map_id, lm_values):
-    verbose_message("Importing {0} lm values for {1}\n".format(len(lm_values),loss_map_id))
+    verbose_message("Importing {0} values for loss_map {1}\n".format(
+        len(lm_values), loss_map_id))
     for lmv in lm_values:
-        verbose_message("Importing lm value {0} {1}\n".format(lmv.asset_ref,lmv.loss))
         cursor.execute(_LOSS_MAP_VALUES_QUERY, [
             loss_map_id,
             lmv.asset_ref,

--- a/python/loss_model.py
+++ b/python/loss_model.py
@@ -96,6 +96,10 @@ class LossMap():
             md.get('metric'),
             md.get('return_period'),
             md)
+        lmvs = md.get('values')
+        if(lmvs is not None):
+            for lmv in lmvs:
+                loss_map.values.append(LossMapValue.from_md(lmv))
         return loss_map
 
 
@@ -135,7 +139,7 @@ class LossCurveMap():
 
     @classmethod
     def from_md(cls, md):
-        return LossCurveMap(
+        lcm = LossCurveMap(
             md.get('occupancy'),
             md.get('component'),
             md.get('loss_type'),
@@ -143,6 +147,11 @@ class LossCurveMap():
             md.get('units'),
             md.get('investigation_time'),
             md)
+        lcmvs = md.get('values')
+        if(lcmvs is not None):
+            for lcmv in lcmvs:
+                lcm.values.append(LossCurveMapValue.from_md(lcmv))
+        return lcm
 
 
 class LossCurveMapValue():

--- a/sql/common.sql
+++ b/sql/common.sql
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS cf_common.license (
 );
 COMMENT ON TABLE cf_common.license IS
 	'List of supported licenses';
-ALTER TABLE cf_common.process_type OWNER TO losscontrib;
+ALTER TABLE cf_common.license OWNER TO losscontrib;
 
 DELETE FROM cf_common.license;
 COPY cf_common.license (code,name,notes,url)

--- a/sql/create-db.sh
+++ b/sql/create-db.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-DB_NAME=loss
 
-createdb $DB_NAME
+. $(readlink -f $(dirname $0))/db_settings.sh
 
-psql -d $DB_NAME << _EOF_
+createdb -U $DB_USER -p $DB_PORT -h $DB_HOST $DB_NAME
+
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME  << _EOF_
 CREATE EXTENSION postgis;
 CREATE ROLE lossusers NOLOGIN NOINHERIT;
 CREATE ROLE lossviewer NOLOGIN INHERIT;

--- a/sql/db_settings.sh.template
+++ b/sql/db_settings.sh.template
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=loss
+DB_USER=
+DATABASE_URL="postgres://$DB_USER@localhost:$DB_PORT/$DB_NAME" 

--- a/sql/db_settings.sh.template
+++ b/sql/db_settings.sh.template
@@ -1,7 +1,8 @@
 #!/bin/sh
-
+# Change DB_USER, and other variables to suit your installation and
+# save as db_settings.sh
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=loss
-DB_USER=
-DATABASE_URL="postgres://$DB_USER@localhost:$DB_PORT/$DB_NAME" 
+DB_USER=@DB_USER@
+DB_URL="postgres://$DB_USER@localhost:$DB_PORT/$DB_NAME" 


### PR DESCRIPTION
This was originally intended to be about support for PostgreSQL 11 and PostGIS 2.5 but also includes some code cleanup, some fixes and support for line-by-line data import.

The export script now forces the order of outputs to facilitate comparisons of resulting json files and avoids serializing the directive dictionary used only on import.
