### PR TITLE
Py3comp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ language: python
 jobs:
   include:
   - stage: test
-    env: PYTHON2
-    python: 2.7
-    install:
-     - pip -q install -U flake8
-    script:
-     - flake8 ./python/
-  - stage: test
     env: PYTHON3
     python: 3.6
     install:

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -31,6 +31,11 @@ db_settings.py
 *.sql
 *.sqlite
 
+#
+# Ignore all JSON files ONLY in python dir
+#
+*.json
+
 # OS generated files #
 ######################
 .DS_Store

--- a/python/database.py
+++ b/python/database.py
@@ -24,7 +24,7 @@ def db_connections(db_confs):
     conns = {}
     for k in db_confs.keys():
         db_conf = db_confs[k]
-        kwargs={}
+        kwargs = {}
         if 'OPTIONS' in db_conf:
             if 'sslmode' in db_conf['OPTIONS']:
                 kwargs['sslmode'] = db_conf['OPTIONS']['sslmode']

--- a/python/database.py
+++ b/python/database.py
@@ -17,26 +17,23 @@
 # along with this program.
 # If not, see <https://www.gnu.org/licenses/agpl.html>.
 #
+import psycopg2
 
-db_confs = {
-    'lossdb': {
-        'NAME': 'loss',
-        'USER': 'lossviewer',
-        'PASSWORD': '<password here>',
-        'HOST': '<hostname>',
-        'PORT': 5432,
-        'OPTIONS': {
-            'sslmode': 'require',
-        }
-    },
-    'losscontrib': {
-        'NAME': 'loss',
-        'USER': 'losscontrib',
-        'PASSWORD': '<password here>',
-        'HOST': '<hostname>',
-        'PORT': 5432,
-        'OPTIONS': {
-            'sslmode': 'require',
-        }
-    }
-}
+
+def db_connections(db_confs):
+    conns = {}
+    for k in db_confs.keys():
+        db_conf = db_confs[k]
+        kwargs={}
+        if 'OPTIONS' in db_conf:
+            if 'sslmode' in db_conf['OPTIONS']:
+                kwargs['sslmode'] = db_conf['OPTIONS']['sslmode']
+
+        conns[k] = psycopg2.connect(user=db_conf['USER'],
+                                    password=db_conf['PASSWORD'],
+                                    host=db_conf['HOST'],
+                                    port=db_conf['PORT'],
+                                    database=db_conf['NAME'],
+                                    **kwargs)
+
+    return conns

--- a/python/export_loss_model.py
+++ b/python/export_loss_model.py
@@ -185,7 +185,6 @@ def _show_loss_models():
     "Display a list of available loss models and ids on stdout"
 
     connections = db_connections(db_settings.db_confs)
-    
     with connections['loss_contrib'].cursor() as cursor:
         License.load_licenses(cursor)
         models = _list_loss_models(cursor)

--- a/python/export_loss_model.py
+++ b/python/export_loss_model.py
@@ -29,12 +29,8 @@ import datetime
 from loss_model import LossModel, LossMap, LossMapValue, \
     LossCurveMap, LossCurveMapValue
 from cf_common import Contribution, License
-
-from django.db import connections
-from django.conf import settings
-
+from database import db_connections
 import db_settings
-settings.configure(DATABASES=db_settings.DATABASES)
 
 
 VERBOSE = True
@@ -187,6 +183,9 @@ def _load_loss_curve_map_values(cursor, loss_map_id, lcm):
 
 def _show_loss_models():
     "Display a list of available loss models and ids on stdout"
+
+    connections = db_connections(db_settings.db_confs)
+    
     with connections['loss_contrib'].cursor() as cursor:
         License.load_licenses(cursor)
         models = _list_loss_models(cursor)
@@ -196,6 +195,9 @@ def _show_loss_models():
 
 def _export_loss_model(model_id):
     "Export the fiven model_id to a json file"
+
+    connections = db_connections(db_settings.db_confs)
+
     verbose_message("Loading model {0}\n".format(
         model_id))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # Python requirements for scripts
 # located in the 'python' folder
-django==1.11.23
 psycopg2


### PR DESCRIPTION
Python 3 compatibility IMPORTANT - Python 2 is no longer supported
Replaced Django dependency with direct use of PostgreSQL via psycopg2 driver
Also adds support for atomic transactions 